### PR TITLE
modified python handler for clear cmd passing in

### DIFF
--- a/blinkt/blinktlink.py
+++ b/blinkt/blinktlink.py
@@ -98,11 +98,11 @@ def handle_command(cmd):
             blinkt.show()
             return
 
-        if cmd == "clear":
+        if cmd.startswith("clear"):
             blinkt.clear()
             blinkt.show()
 
-        if cmd == "stop":
+        if cmd.startswith("stop"):
             stdin.stop()
             running = False
 


### PR DESCRIPTION
Calling the clear command doesn't work as the python handler expects the `cmd == "clear"`

Javascript always sends a : as part of the message topic and payload separator.  
`HAT.send(msg.topic + ":" + msg.payload.toString());`

A change to startswith("") solves the issue and is consistent with the other handlers in blinktlink.py